### PR TITLE
incorporate jemalloc in electrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
  "stderrlog",
  "sysconf",
  "tempfile",
+ "tikv-jemallocator",
  "time 0.3.9",
  "tiny_http",
  "tokio",
@@ -1586,6 +1587,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ signal-hook = "0.3"
 stderrlog = "0.5.0"
 sysconf = ">=0.3.4"
 time = { version = "0.3", features = ["formatting"] }
+tikv-jemallocator = { version = "0.5.4" }
 tiny_http = "0.11"
 url = "2.2.0"
 hyper = "0.14"

--- a/src/bin/electrs.rs
+++ b/src/bin/electrs.rs
@@ -1,3 +1,8 @@
+use tikv_jemallocator::Jemalloc;
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 extern crate error_chain;
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
### Summary

Incorporates `jemalloc` dependency to seek better memory utilization in `electrs`. @domZippilli's [PR](https://github.com/cequals/lightning-node/pull/827) write up provides an excellent summary of the potential benefits of using it.


### Testing
Deployed successfully to staging env. Would likely need to monitor in Production over a longer period of time to see if the service will continue to experience the spikes in memory utilization in Electrs tasks.